### PR TITLE
Fix markdown re-rendering bug

### DIFF
--- a/src/components/resource_entry.ts
+++ b/src/components/resource_entry.ts
@@ -33,7 +33,7 @@ class ResourceEntry extends React.Component<ResourceEntry.Props, {}> {
     return r.div({ },
       r.div({ },
         r.h3({ }, "Resource description"),
-        r.p({ dangerouslySetInnerHTML: {
+        r.div({ dangerouslySetInnerHTML: {
           __html: marked(resource.comment, { sanitize: true }) }
         })
       )

--- a/src/components/route_entry.ts
+++ b/src/components/route_entry.ts
@@ -31,7 +31,7 @@ class RouteEntry extends React.Component<RouteEntry.Props, {}> {
   private renderRouteInfo = () => {
     return r.div({ },
       r.h3({ }, "Route description"),
-      r.p({ dangerouslySetInnerHTML: {
+      r.div({ dangerouslySetInnerHTML: {
         __html: marked(this.props.action.comment, { sanitize: true }) }
       }),
       r.hr({ }),


### PR DESCRIPTION
You can't have nested `<p>` tags, so react un-nested them which made
the comment areas not update reactively.