### PR TITLE
Remove deprecated React.addons.classSet

### DIFF
--- a/src/class_names.ts
+++ b/src/class_names.ts
@@ -1,0 +1,35 @@
+/**
+ * A utility to concatenate multiple classNames into a single string.
+ * The first parameter may also be a "classSet", an object with classNames
+ * as keys mapping to boolean values indicating whether or not the given
+ * className should be included.
+ * @param  {(ClassSet | string)} arg - classSet or first className
+ * @param  {...string} className - extra className to append
+ * @return {string} the complete concatenated className
+ */
+function classNames(
+    arg: ({ [key: string]: boolean } | string),
+    ...extraClasses: string[]
+): string {
+
+    var className = "";
+    if (typeof arg === "object") {
+        for (var name in arg) {
+            if (arg.hasOwnProperty(name) && arg[name]) {
+                className += " " + name;
+            }
+        }
+    } else if (arg) {
+        className = " " + arg;
+    }
+
+    var i: number;
+    for (i = 0; i < extraClasses.length; ++i) {
+        if (extraClasses[i]) {
+            className += " " + extraClasses[i];
+        }
+    }
+    return className.substr(1);
+}
+
+export = classNames;

--- a/src/components/json_response.ts
+++ b/src/components/json_response.ts
@@ -1,8 +1,7 @@
 /// <reference path="../resources/interfaces.ts" />
+import cx = require("../class_names");
 import React = require("react/addons");
 
-// TODO: Remove deprecated classSet.
-var cx = React.addons.classSet;
 var r = React.DOM;
 
 /**

--- a/src/components/parameter_entry.ts
+++ b/src/components/parameter_entry.ts
@@ -1,10 +1,9 @@
 /// <reference path="../asana.d.ts" />
 /// <reference path="../resources/interfaces.ts" />
 import Asana = require("asana");
+import cx = require("../class_names");
 import React = require("react/addons");
 
-// TODO: Remove deprecated classSet.
-var cx = React.addons.classSet;
 var r = React.DOM;
 
 /**

--- a/test/class_names_spec.ts
+++ b/test/class_names_spec.ts
@@ -1,0 +1,33 @@
+import chai = require("chai");
+import cx = require("../src/class_names");
+
+var assert = chai.assert;
+
+suite("classNames", () => {
+
+    test("should filter to return only truthy strings", () => {
+        assert.equal(cx({
+            foo: true,
+            bar: undefined,
+            baz: true,
+            fire: null,
+            foobar: false
+        }), "foo baz");
+    });
+
+    test("should append extra class strings", () => {
+        assert.equal(cx({
+            baz: false,
+            boo: true,
+            bar: true
+        }, "a", "b", "c"), "boo bar a b c");
+    });
+
+    test("should also accept a string as the first argument", () => {
+        assert.equal(cx("foobar", "foo", "baz"), "foobar foo baz");
+    });
+
+    test("should filter out falsy values", () => {
+        assert.equal(cx(null, "foo", undefined, "bar"), "foo bar");
+    });
+});


### PR DESCRIPTION
- Removes use of `React.addons.classSet
- Replace usages with new `classNames`