### PR TITLE
Fix resource param in /events route

### DIFF
--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -145,17 +145,27 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
       params = _.extend(params, this.state.params.paginateParams);
     }
 
-    // The first required parameter is injected into the URL.
-    // Other required parameters are included here, so we extract them out.
+    // Sometimes, the first required param is put into the URL directly, whereas
+    // other times we put the required params as a request parameter.
     var requiredParams = _.filter(this.state.action.params, "required");
-    if (requiredParams.length > 1) {
+    if (ResourcesHelpers.pathForActionContainsRequiredParam(this.state.action)) {
+      // The first required param is put into the URL, so include later ones.
+      if (requiredParams.length > 1) {
+        _.forEach(
+            this.state.params.requiredParams,
+            (value: string, key: string) => {
+              if (requiredParams[0].name !== key) {
+                params[key] = value;
+              }
+            });
+      }
+    } else {
+      // The first required param is not in the URL, so include them all.
       _.forEach(
-        this.state.params.requiredParams,
-        (value: string, key: string) => {
-          if (requiredParams[0].name !== key) {
+          this.state.params.requiredParams,
+          (value: string, key: string) => {
             params[key] = value;
-          }
-        });
+      });
     }
 
     // If an optional param is for workspace, then inject the chosen workspace.

--- a/src/resources/helpers.ts
+++ b/src/resources/helpers.ts
@@ -80,7 +80,7 @@ export function defaultActionFromResource(resource: Resource): Action {
  */
 export function pathForAction(action: Action, param_value?: number): string {
   // If there's a placeholder, then replace it with its required param.
-  if (action.path.match(/%/g) !== null) {
+  if (pathForActionContainsRequiredParam(action)) {
     var requiredParam = _.find(action.params, "required");
     if (requiredParam === undefined) {
       throw new Error("Placeholder in path but there's no required param.");
@@ -98,4 +98,15 @@ export function pathForAction(action: Action, param_value?: number): string {
 
   // Otherwise, we just return the path.
   return action.path;
+}
+
+/**
+ * Given an action, checks the path to check if there's a placeholder value for
+ * a required param.
+ *
+ * @param action
+ * @returns {boolean}
+ */
+export function pathForActionContainsRequiredParam(action: Action): boolean {
+  return action.path.match(/%/g) !== null;
 }


### PR DESCRIPTION
We previously assumed that all first required params were put
into the URL directly, rather then as request parameters. This
was not true for the `/events` endpoint, which meant that you could
not include a `resource` parameter when making a request.