### PR TITLE
Add Client Side OAuth to the API explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bity/oauth2-auth-code-pkce": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bity/oauth2-auth-code-pkce/-/oauth2-auth-code-pkce-2.9.0.tgz",
+      "integrity": "sha512-lPvVzUmiFp1lVgvd814fJpU3jnNdNiPVsKG9nCsKf4q5X8CGtp8mVcg6J5Bb2Vij/ntnQINbCLZW2U0xj/cFGw=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
@@ -260,7 +265,8 @@
     "@types/lodash": {
       "version": "4.14.149",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
     },
     "@types/marked": {
       "version": "0.6.5",
@@ -318,6 +324,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.0.tgz",
       "integrity": "sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==",
+      "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -325,7 +332,8 @@
     "@types/sinonjs__fake-timers": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
     },
     "@types/tough-cookie": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "uglify-js": "^2.4.23"
   },
   "dependencies": {
+    "@bity/oauth2-auth-code-pkce": "^2.9.0",
     "asana": "^0.17.3",
     "bluebird": "^2.11.0",
     "immutability-helper": "^3.0.2",

--- a/src/asana.d.ts
+++ b/src/asana.d.ts
@@ -11,6 +11,7 @@ declare module "asana" {
     workspaces: resources.Workspaces;
     static create(options?: any): Client;
     useOauth(options?: any): Client;
+    useAccessToken(accessToken: String): Client;
     authorize(): Promise<Client>;
   }
 

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -102,7 +102,7 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
      * Authorize the client, if it has expired, and force a re-rendering.
      */
     authorize = (): void => {
-        this.props.oAuth.fetchAuthorizationCode();
+        this.props.OAuth.fetchAuthorizationCode();
     }
 
     setCredentialsFromOAuth = (token: String): void => {
@@ -128,7 +128,7 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
         }).catch((e: any) => {
             this.setState({authState: Credentials.AuthState.Expired})
             window.localStorage.clear()
-            this.props.oAuth.reset()
+            // this.props.OAuth.reset()
         })
     }
 

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -4,6 +4,7 @@ import Asana = require("asana");
 import * as React from "react";
 import url = require("url");
 import _ = require("lodash");
+import {OAuth2AuthCodePKCE} from "@bity/oauth2-auth-code-pkce"
 
 import constants = require("../constants");
 import Credentials = require("../credentials");
@@ -20,6 +21,7 @@ import update from "immutability-helper";
 import ResourcesHelpers = require("../resources/helpers");
 
 const r = React.createElement;
+
 
 /**
  * If a client exists in props, use it. Otherwise, make a new one.
@@ -100,19 +102,15 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
      * Authorize the client, if it has expired, and force a re-rendering.
      */
     authorize = (): void => {
-        if (this.state.client === undefined) {
-            return;
-        }
-        this.state.client.authorize().then(client => {
-            Credentials.storeFromClient(client);
-            // @ts-ignore
-            this.state.authState = Credentials.authStateFromClient(client);
+        this.props.oAuth.fetchAuthorizationCode();
+    }
 
-            // After authorization, perform tasks that require authentication.
-            this.fetchAndStoreWorkspaces();
-
-            this.forceUpdate();
-        });
+    setCredentialsFromOAuth = (token: String): void => {
+        this.state.client.useAccessToken(token)
+        this.setState({authState: Credentials.AuthState.Authorized})
+        window.history.replaceState({}, document.title, window.location.href.split("?")[0]);
+        this.fetchAndStoreWorkspaces();
+        this.forceUpdate();
     }
 
     /**
@@ -127,7 +125,11 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
                 workspace: workspaces.data[0],
                 workspaces: workspaces.data
             });
-        });
+        }).catch((e: any) => {
+            this.setState({authState: Credentials.AuthState.Expired})
+            window.localStorage.clear()
+            this.props.oAuth.reset()
+        })
     }
 
     /**
@@ -749,6 +751,7 @@ module Explorer {
         initialClient?: Asana.Client;
         initialResourceString?: string;
         initialRoute?: string;
+        OAuth?: OAuth2AuthCodePKCE;
     }
 
     /**

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -128,7 +128,6 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
         }).catch((e: any) => {
             this.setState({authState: Credentials.AuthState.Expired})
             window.localStorage.clear()
-            // this.props.OAuth.reset()
         })
     }
 

--- a/src/components/explorer.ts
+++ b/src/components/explorer.ts
@@ -102,7 +102,7 @@ class Explorer extends React.Component<Explorer.Props, Explorer.State> {
      * Authorize the client, if it has expired, and force a re-rendering.
      */
     authorize = (): void => {
-        this.props.OAuth.fetchAuthorizationCode();
+        this.props.oauth.fetchAuthorizationCode();
     }
 
     setCredentialsFromOAuth = (token: String): void => {
@@ -750,7 +750,7 @@ module Explorer {
         initialClient?: Asana.Client;
         initialResourceString?: string;
         initialRoute?: string;
-        OAuth?: OAuth2AuthCodePKCE;
+        oauth?: OAuth2AuthCodePKCE;
     }
 
     /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ interface BaseConstants {
   LOCALSTORAGE_KEY: string;
   CLIENT_ID: string;
   REDIRECT_URI: string;
+  TOKEN_URL: string;
   INITIAL_PAGINATION_LIMIT: number;
 }
 
@@ -9,6 +10,7 @@ var ghPagesConstants: BaseConstants = {
   LOCALSTORAGE_KEY: "api_explorer_credentials",
   CLIENT_ID: "29147353239426",
   REDIRECT_URI: "https://asana.github.io/api-explorer/popup_receiver.html",
+  TOKEN_URL: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
   INITIAL_PAGINATION_LIMIT: 10
 };
 
@@ -16,6 +18,7 @@ var localhostConstants: BaseConstants = {
   LOCALSTORAGE_KEY: "api_explorer_credentials",
   CLIENT_ID: "23824292948206",
   REDIRECT_URI: "http://localhost:8338/popup_receiver.html",
+  TOKEN_URL: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
   INITIAL_PAGINATION_LIMIT: 10
 };
 
@@ -23,6 +26,7 @@ var production: BaseConstants = {
   LOCALSTORAGE_KEY: "api_explorer_credentials",
   CLIENT_ID: "38682966449842",
   REDIRECT_URI: "https://asana.github.io/developer-docs/explorer/popup_receiver.html",
+  TOKEN_URL: "https://jikyuaso9e.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
   INITIAL_PAGINATION_LIMIT: 10
 };
 

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,13 +1,40 @@
 import ReactDOM = require("react-dom");
-
+import {OAuth2AuthCodePKCE} from "@bity/oauth2-auth-code-pkce"
 import Explorer = require("./components/explorer");
 
 /**
  * Creates and renders the API Explorer component.
  */
+
+const oauth = new OAuth2AuthCodePKCE({
+  authorizationUrl: "https://app.asana.com/-/oauth_authorize",
+  tokenUrl: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
+  clientId: "23824292948206",
+  redirectUrl: "http://localhost:8338/",
+  scopes: [],
+  onInvalidGrant(){
+      console.log("Expired! Auth code or refresh token needs to be renewed.");
+  },
+  onAccessTokenExpiry(refreshAccessToken) {
+      console.log("Expired! Access token needs to be renewed.");
+      return refreshAccessToken()
+  }
+});
+
+
 export function run(initialResource?: string, initialRoute?: string): void {
-  ReactDOM.render(Explorer.create({
+  const explorer = ReactDOM.render(Explorer.create({
     initialResourceString: initialResource,
-    initialRoute: initialRoute
+    initialRoute: initialRoute,
+    OAuth: oauth
   }), document.getElementById("tab-explorer"));
+
+  oauth.isReturningFromAuthServer().then(hasAuthCode => {
+    return oauth.getAccessToken().then((tokenResponse) => {
+        explorer.setCredentialsFromOAuth(tokenResponse.token.value)
+    });
+  })
+  .catch((potentialError) => {
+    if (potentialError) { console.log(potentialError); }
+  });
 }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,6 +1,8 @@
 import ReactDOM = require("react-dom");
 import {OAuth2AuthCodePKCE} from "@bity/oauth2-auth-code-pkce"
 import Explorer = require("./components/explorer");
+import constants = require("./constants");
+
 
 /**
  * Creates and renders the API Explorer component.
@@ -9,7 +11,7 @@ import Explorer = require("./components/explorer");
 const oauth = new OAuth2AuthCodePKCE({
   authorizationUrl: "https://app.asana.com/-/oauth_authorize",
   tokenUrl: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
-  clientId: "23824292948206",
+  clientId: constants.CLIENT_ID,
   redirectUrl: window.location.href.split("?")[0],
   scopes: [],
   onInvalidGrant(){

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -10,7 +10,7 @@ import constants = require("./constants");
 
 const oauth = new OAuth2AuthCodePKCE({
   authorizationUrl: "https://app.asana.com/-/oauth_authorize",
-  tokenUrl: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
+  tokenUrl: constants.TOKEN_URL,
   clientId: constants.CLIENT_ID,
   redirectUrl: window.location.href.split("?")[0],
   scopes: [],
@@ -28,7 +28,7 @@ export function run(initialResource?: string, initialRoute?: string): void {
   const explorer = ReactDOM.render(Explorer.create({
     initialResourceString: initialResource,
     initialRoute: initialRoute,
-    OAuth: oauth
+    oauth
   }), document.getElementById("tab-explorer"));
 
   oauth.isReturningFromAuthServer().then(() => {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -10,7 +10,7 @@ const oauth = new OAuth2AuthCodePKCE({
   authorizationUrl: "https://app.asana.com/-/oauth_authorize",
   tokenUrl: "https://ccbv8pweoe.execute-api.us-east-1.amazonaws.com/default/api_explorer_oauth_beta",
   clientId: "23824292948206",
-  redirectUrl: "http://localhost:8338/",
+  redirectUrl: window.location.href.split("?")[0],
   scopes: [],
   onInvalidGrant(){
       console.log("Expired! Auth code or refresh token needs to be renewed.");
@@ -29,7 +29,7 @@ export function run(initialResource?: string, initialRoute?: string): void {
     OAuth: oauth
   }), document.getElementById("tab-explorer"));
 
-  oauth.isReturningFromAuthServer().then(hasAuthCode => {
+  oauth.isReturningFromAuthServer().then(() => {
     return oauth.getAccessToken().then((tokenResponse) => {
         explorer.setCredentialsFromOAuth(tokenResponse.token.value)
     });


### PR DESCRIPTION
This PR implements client side OAuth using PKCE in the API explorer. I have tested that we are able to make successful requests when a user is authorized and that once a token is expired the re-authentication flow works as expected.

Things to note:
- We currently define `onInvalidGrant` and `onAccessTokenExpiry` when creating an instance of `OAuth2AuthCodePKCE` but we do not use them.
- We are no longer using a pop up window for the auth flow. I can look into re-implementing that.